### PR TITLE
feat: use rimraf to delete dist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "install-peers-cli": "^2.2.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
+    "rimraf": "^3.0.2",
     "typescript": "^4.7.4"
   },
   "scripts": {
@@ -63,7 +64,7 @@
     "prepublishOnly": "run-s clean install-peers build",
     "lint": "eslint src/**/*",
     "prepare": "husky install",
-    "clean": "rm -rf dist"
+    "clean": "rimraf dist"
   },
   "peerDependencies": {
     "react": ">16.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2460,7 +2460,7 @@ reusify@^1.0.4:
 
 rimraf@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"


### PR DESCRIPTION
## Description

This commit adds the support for rimraf to delete all the build files, making it portable for multiple systems.

Closes #12 


### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **Commits descriptions**: All commits in this PR contain a title and description according to [CONTRIBUTING.md](https://github.com/profusion/quickstart-nodejs-rest/blob/master/doc/CONTRIBUTING.md#commits).

<!-- Also, don't forget to review your code before marking it as ready to merge -->

## How to test it

Use `yarn clean`

## Change logs

* add `rimraf` as devDep
* reworked clean command to use `rimraf`
