### PR TITLE
feat: generate .d.ts files only once

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@profusion/use-location-query-state",
   "version": "1.0.4",
   "license": "MIT",
-  "types": "./dist/esm/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "files": ["dist"],
@@ -57,7 +57,7 @@
   },
   "scripts": {
     "build:esm": "tsc",
-    "build:cjs": "tsc --outDir dist/cjs --moduleResolution node",
+    "build:cjs": "tsc -p ./tsconfig.cjs.json",
     "build": "run-p build:esm build:cjs && sh ./.scripts/batch-packages.sh",
     "install-peers": "install-peers -f",
     "prepublishOnly": "run-s clean install-peers build",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "declaration": false,
+    "declarationMap": false,
+    "declarationDir": null,
+    "moduleResolution": "node",
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "./dist/esm",
     "declaration": true,
     "declarationMap": true,
+    "declarationDir": "./dist/types",
     "noImplicitAny": true,
     "sourceMap": false,
     "removeComments": false,


### PR DESCRIPTION
## Description

This commit adds the support for generting the .d.ts files only once and also split the build into different build configs making it easier to maintain

Fixes #11

<!-- Open this PR as draft while it is not ready -->

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **Commits descriptions**: All commits in this PR contain a title and description according to [CONTRIBUTING.md](https://github.com/profusion/quickstart-nodejs-rest/blob/master/doc/CONTRIBUTING.md#commits).

<!-- Also, don't forget to review your code before marking it as ready to merge -->

## How to test it
run `yarn build`
