### PR TITLE
fix: generate d.ts files only once

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "name": "@profusion/use-location-query-state",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MIT",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "repository": "https://github.com/profusion/use-location-query-state",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@profusion/use-location-query-state",
   "version": "1.0.4",
   "license": "MIT",
-  "types": "./dist/esm/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "files": ["dist"],
@@ -10,26 +10,32 @@
   "repository": "https://github.com/profusion/use-location-query-state",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./options/*": {
+      "types": "./dist/types/options/*.d.ts",
       "import": "./dist/esm/options/*.js",
       "require": "./dist/cjs/options/*.js"
     },
     "./converters/*": {
+      "types": "./dist/types/converters/*.d.ts",
       "import": "./dist/esm/converters/*.js",
       "require": "./dist/cjs/converters/*.js"
     },
     "./browser-window-options": {
+      "types": "./dist/types/options/browserWindowLocationOptions.d.ts",
       "import": "./dist/esm/options/browserWindowLocationOptions.js",
       "require": "./dist/cjs/options/browserWindowLocationOptions.js"
     },
     "./react-router-options": {
+      "types": "./dist/types/options/reactRouterLocationOptions.d.ts",
       "import": "./dist/esm/options/reactRouterLocationOptions.js",
       "require": "./dist/cjs/options/reactRouterLocationOptions.js"
     },
     "./core": {
+      "types": "./dist/types/useLocationQueryState.d.ts",
       "import": "./dist/esm/useLocationQueryState.js",
       "require": "./dist/cjs/useLocationQueryState.js"
     }
@@ -58,7 +64,7 @@
   },
   "scripts": {
     "build:esm": "tsc",
-    "build:cjs": "tsc --outDir dist/cjs --moduleResolution node",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
     "build": "run-p build:esm build:cjs && sh ./.scripts/batch-packages.sh",
     "install-peers": "install-peers -f",
     "prepublishOnly": "run-s clean install-peers build",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationDir": null,
+    "declarationMap": false,
+    "moduleResolution": "node",
+    "outDir": "./dist/cjs"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "Node16",
     "outDir": "./dist/esm",
     "declaration": true,
+    "declarationDir": "./dist/types",
     "declarationMap": true,
     "noImplicitAny": true,
     "sourceMap": false,


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

Stop generating d.ts files for each build. They are the same and can be reused.

## Related Issues

Closes #11 

## Progress

<!-- If your PR is WIP, use checkboxes to show that you did and what you have to do. For example:

- [x] New endpoint created;
- [ ] Update organizations;
- [ ] Create tests;
-->

<!-- Also, don't forget to review your code before marking it as ready to merge -->

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [ ] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

<!-- Describe how the reviewers can test your feature. -->

## Visual reference

<!--
Please include screenshots, gifs or recordings
For example: if this is a bug fix, provide before and after screenshots

<img width="350" alt="Screenshot of bug fix" src="your-image-url-here">

Before | After
:-:|:-:
<img width="350" alt="Screenshot of screen pre bug fix" src="your-image-url-here"> | <img width="350" alt="Screenshot of screen post bug fix" src="your-image-url-here">
-->
